### PR TITLE
Simplify library usage

### DIFF
--- a/dist/bulma.js
+++ b/dist/bulma.js
@@ -73,7 +73,7 @@ var Bulma = {
      * Current BulmaJS version.
      * @type {String}
      */
-    VERSION: '0.1.0',
+    VERSION: '0.2.0',
 
     /**
      * Helper method to create a new plugin.

--- a/dist/bulma.js
+++ b/dist/bulma.js
@@ -60,7 +60,7 @@
 /******/ 	__webpack_require__.p = "";
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 7);
+/******/ 	return __webpack_require__(__webpack_require__.s = 1);
 /******/ })
 /************************************************************************/
 /******/ ([
@@ -119,22 +119,60 @@ var Bulma = {
     }
 };
 
+document.addEventListener('DOMContentLoaded', function (event) {
+    Bulma.traverseDOM();
+});
+
 /* harmony default export */ __webpack_exports__["a"] = (Bulma);
 
 /***/ }),
 /* 1 */
+/***/ (function(module, exports, __webpack_require__) {
+
+module.exports = __webpack_require__(2);
+
+
+/***/ }),
+/* 2 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__core__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__plugins_notification__ = __webpack_require__(3);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__plugins_navbar__ = __webpack_require__(4);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__plugins_message__ = __webpack_require__(5);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__plugins_dropdown__ = __webpack_require__(6);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__plugins_modal__ = __webpack_require__(7);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__plugins_file__ = __webpack_require__(8);
+
+
+
+
+
+
+
+
+window.Bulma = __WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */];
+
+/***/ }),
+/* 3 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__core__ = __webpack_require__(0);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+
 
 /**
  * @module Notification
  * @since  0.1.0
  * @author  Thomas Erbe <vizuaalog@gmail.com>
  */
+
 var Notification = function () {
     /**
      * Plugin constructor
@@ -393,22 +431,28 @@ var Notification = function () {
     return Notification;
 }();
 
-/* harmony default export */ __webpack_exports__["a"] = (Notification);
+__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('notification', Notification);
+
+/* unused harmony default export */ var _unused_webpack_default_export = (Notification);
 
 /***/ }),
-/* 2 */
+/* 4 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__core__ = __webpack_require__(0);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+
 
 /**
  * @module Navbar
  * @since  0.1.0
  * @author  Thomas Erbe <vizuaalog@gmail.com>
  */
+
 var Navbar = function () {
     /**
      * Plugin constructor
@@ -490,22 +534,28 @@ var Navbar = function () {
     return Navbar;
 }();
 
-/* harmony default export */ __webpack_exports__["a"] = (Navbar);
+__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('navbar', Navbar);
+
+/* unused harmony default export */ var _unused_webpack_default_export = (Navbar);
 
 /***/ }),
-/* 3 */
+/* 5 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__core__ = __webpack_require__(0);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+
 
 /**
  * @module Message
  * @since  0.1.0
  * @author  Thomas Erbe <vizuaalog@gmail.com>
  */
+
 var Message = function () {
     /**
      * Plugin constructor
@@ -819,22 +869,28 @@ var Message = function () {
     return Message;
 }();
 
-/* harmony default export */ __webpack_exports__["a"] = (Message);
+__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('message', Message);
+
+/* unused harmony default export */ var _unused_webpack_default_export = (Message);
 
 /***/ }),
-/* 4 */
+/* 6 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__core__ = __webpack_require__(0);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+
 
 /**
  * @module Dropdown
  * @since  0.1.0
  * @author  Thomas Erbe <vizuaalog@gmail.com>
  */
+
 var Dropdown = function () {
     /**
      * Plugin constructor
@@ -908,22 +964,28 @@ var Dropdown = function () {
     return Dropdown;
 }();
 
-/* harmony default export */ __webpack_exports__["a"] = (Dropdown);
+__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('dropdown', Dropdown);
+
+/* unused harmony default export */ var _unused_webpack_default_export = (Dropdown);
 
 /***/ }),
-/* 5 */
+/* 7 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__core__ = __webpack_require__(0);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+
 
 /**
  * @module Modal
  * @since  0.1.0
  * @author  Thomas Erbe <vizuaalog@gmail.com>
  */
+
 var Modal = function () {
   /**
    * Plugin constructor
@@ -1049,22 +1111,28 @@ var Modal = function () {
   return Modal;
 }();
 
-/* harmony default export */ __webpack_exports__["a"] = (Modal);
+__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('modal', Modal);
+
+/* unused harmony default export */ var _unused_webpack_default_export = (Modal);
 
 /***/ }),
-/* 6 */
+/* 8 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__core__ = __webpack_require__(0);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+
 
 /**
  * @module File
  * @since  0.1.0
  * @author  Thomas Erbe <vizuaalog@gmail.com>
  */
+
 var File = function () {
     /**
      * Plugin constructor
@@ -1168,50 +1236,9 @@ var File = function () {
     return File;
 }();
 
-/* harmony default export */ __webpack_exports__["a"] = (File);
+__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('file', File);
 
-/***/ }),
-/* 7 */
-/***/ (function(module, exports, __webpack_require__) {
-
-module.exports = __webpack_require__(8);
-
-
-/***/ }),
-/* 8 */
-/***/ (function(module, __webpack_exports__, __webpack_require__) {
-
-"use strict";
-Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__core__ = __webpack_require__(0);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__plugins_notification__ = __webpack_require__(1);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__plugins_navbar__ = __webpack_require__(2);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__plugins_message__ = __webpack_require__(3);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__plugins_dropdown__ = __webpack_require__(4);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__plugins_modal__ = __webpack_require__(5);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__plugins_file__ = __webpack_require__(6);
-
-
-
-__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('notification', __WEBPACK_IMPORTED_MODULE_1__plugins_notification__["a" /* default */]);
-
-
-__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('navbar', __WEBPACK_IMPORTED_MODULE_2__plugins_navbar__["a" /* default */]);
-
-
-__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('message', __WEBPACK_IMPORTED_MODULE_3__plugins_message__["a" /* default */]);
-
-
-__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('dropdown', __WEBPACK_IMPORTED_MODULE_4__plugins_dropdown__["a" /* default */]);
-
-
-__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('modal', __WEBPACK_IMPORTED_MODULE_5__plugins_modal__["a" /* default */]);
-
-
-__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('file', __WEBPACK_IMPORTED_MODULE_6__plugins_file__["a" /* default */]);
-
-__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].traverseDOM();
-window.Bulma = __WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */];
+/* unused harmony default export */ var _unused_webpack_default_export = (File);
 
 /***/ })
 /******/ ]);

--- a/dist/dropdown.js
+++ b/dist/dropdown.js
@@ -120,6 +120,10 @@ var Bulma = {
     }
 };
 
+document.addEventListener('DOMContentLoaded', function (event) {
+    Bulma.traverseDOM();
+});
+
 /* harmony default export */ __webpack_exports__["a"] = (Bulma);
 
 /***/ }),
@@ -152,15 +156,19 @@ window.Bulma = __WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */];
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__core__ = __webpack_require__(0);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+
 
 /**
  * @module Dropdown
  * @since  0.1.0
  * @author  Thomas Erbe <vizuaalog@gmail.com>
  */
+
 var Dropdown = function () {
     /**
      * Plugin constructor
@@ -233,6 +241,8 @@ var Dropdown = function () {
 
     return Dropdown;
 }();
+
+__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('dropdown', Dropdown);
 
 /* harmony default export */ __webpack_exports__["a"] = (Dropdown);
 

--- a/dist/file.js
+++ b/dist/file.js
@@ -120,6 +120,10 @@ var Bulma = {
     }
 };
 
+document.addEventListener('DOMContentLoaded', function (event) {
+    Bulma.traverseDOM();
+});
+
 /* harmony default export */ __webpack_exports__["a"] = (Bulma);
 
 /***/ }),
@@ -152,15 +156,19 @@ window.Bulma = __WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */];
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__core__ = __webpack_require__(0);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+
 
 /**
  * @module File
  * @since  0.1.0
  * @author  Thomas Erbe <vizuaalog@gmail.com>
  */
+
 var File = function () {
     /**
      * Plugin constructor
@@ -263,6 +271,8 @@ var File = function () {
 
     return File;
 }();
+
+__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('file', File);
 
 /* harmony default export */ __webpack_exports__["a"] = (File);
 

--- a/dist/message.js
+++ b/dist/message.js
@@ -120,6 +120,10 @@ var Bulma = {
     }
 };
 
+document.addEventListener('DOMContentLoaded', function (event) {
+    Bulma.traverseDOM();
+});
+
 /* harmony default export */ __webpack_exports__["a"] = (Bulma);
 
 /***/ }),
@@ -152,15 +156,19 @@ window.Bulma = __WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */];
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__core__ = __webpack_require__(0);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+
 
 /**
  * @module Message
  * @since  0.1.0
  * @author  Thomas Erbe <vizuaalog@gmail.com>
  */
+
 var Message = function () {
     /**
      * Plugin constructor
@@ -473,6 +481,8 @@ var Message = function () {
 
     return Message;
 }();
+
+__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('message', Message);
 
 /* harmony default export */ __webpack_exports__["a"] = (Message);
 

--- a/dist/modal.js
+++ b/dist/modal.js
@@ -120,6 +120,10 @@ var Bulma = {
     }
 };
 
+document.addEventListener('DOMContentLoaded', function (event) {
+    Bulma.traverseDOM();
+});
+
 /* harmony default export */ __webpack_exports__["a"] = (Bulma);
 
 /***/ }),
@@ -152,15 +156,19 @@ window.Bulma = __WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */];
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__core__ = __webpack_require__(0);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+
 
 /**
  * @module Modal
  * @since  0.1.0
  * @author  Thomas Erbe <vizuaalog@gmail.com>
  */
+
 var Modal = function () {
   /**
    * Plugin constructor
@@ -285,6 +293,8 @@ var Modal = function () {
 
   return Modal;
 }();
+
+__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('modal', Modal);
 
 /* harmony default export */ __webpack_exports__["a"] = (Modal);
 

--- a/dist/navbar.js
+++ b/dist/navbar.js
@@ -119,6 +119,10 @@ var Bulma = {
     }
 };
 
+document.addEventListener('DOMContentLoaded', function (event) {
+    Bulma.traverseDOM();
+});
+
 /* harmony default export */ __webpack_exports__["a"] = (Bulma);
 
 /***/ }),
@@ -127,15 +131,19 @@ var Bulma = {
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__core__ = __webpack_require__(0);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+
 
 /**
  * @module Navbar
  * @since  0.1.0
  * @author  Thomas Erbe <vizuaalog@gmail.com>
  */
+
 var Navbar = function () {
     /**
      * Plugin constructor
@@ -216,6 +224,8 @@ var Navbar = function () {
 
     return Navbar;
 }();
+
+__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('navbar', Navbar);
 
 /* harmony default export */ __webpack_exports__["a"] = (Navbar);
 

--- a/dist/notification.js
+++ b/dist/notification.js
@@ -119,6 +119,10 @@ var Bulma = {
     }
 };
 
+document.addEventListener('DOMContentLoaded', function (event) {
+    Bulma.traverseDOM();
+});
+
 /* harmony default export */ __webpack_exports__["a"] = (Bulma);
 
 /***/ }),
@@ -126,15 +130,19 @@ var Bulma = {
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__core__ = __webpack_require__(0);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+
 
 /**
  * @module Notification
  * @since  0.1.0
  * @author  Thomas Erbe <vizuaalog@gmail.com>
  */
+
 var Notification = function () {
     /**
      * Plugin constructor
@@ -392,6 +400,8 @@ var Notification = function () {
 
     return Notification;
 }();
+
+__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('notification', Notification);
 
 /* harmony default export */ __webpack_exports__["a"] = (Notification);
 

--- a/docs/_includes/code/import-singular.js
+++ b/docs/_includes/code/import-singular.js
@@ -1,8 +1,11 @@
 // Import BulmaJS plugin
-import Notification from 'path/to/bulmajs/src/Notification';
+import Notification from 'path/to/bulmajs/src/plugins/Notification';
+import Navbar from 'path/to/bulmajs/src/plugins/Navbar';
 
-// You will now have access to the Bulma global.
-// Any notifications created in the DOM with the data-bulma API
-// Will have been initialised.
+// Everything is now setup. One document ready the DOM will be parsed.
+// If you would like to register a Bulma global, you can import Bulma
+import Bulma from 'path/to/bulmajs/src/core';
 
-// No more setup is required.
+// This will allow you to assign Bulma to the window. Your ES6 transpiling
+// system should only include the core in your output once.
+window.Bulma = Bulma;

--- a/docs/_includes/code/import-src.js
+++ b/docs/_includes/code/import-src.js
@@ -1,13 +1,5 @@
-// Import BulmaJS core and plugins
-import Bulma from 'path/to/bulmajs/src/core';
-import Notification from 'path/to/bulmajs/src/plugins/Notification';
+// Import all of Bulma
+import Bulma from 'bulma';
 
-// Register plugins with the core
-Bulma.registerPlugin('notification', Notification);
-
-// If you want to use the DOM API, execute the following function
-// when the DOM has loaded
-Bulma.traverseDOM();
-
-// If you would like global access to Bulma
-window.Bulma = Bulma; // This can be anything you want
+// Done! All plugins have been loaded and are available to use
+// either via the DOM API or through Javascript.

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -15,7 +15,7 @@
                 <a class="navbar-item" href="{{ site.url }}">
                     Overview
                     &nbsp;
-                    <span class="tag is-primary">0.1.0</span>
+                    <span class="tag is-primary">0.2.0</span>
                 </a>
 
                 <div class="navbar-item has-dropdown is-hoverable">

--- a/docs/_layouts/home.html
+++ b/docs/_layouts/home.html
@@ -19,7 +19,7 @@ layout: default
         <h4 class="subtitle">This requires a build process to be in-place to transpile the ES6 code to ES5.</h4>
 
         <div class="content">
-            <p>BulmaJS has a flexible system for using only the component you need in your project. If you would like to build you own library of BulmaJS plugins, you can use the below syntax.</p>
+            <p>The easiest way to get started with BulmaJS is to load everything.</p>
         </div>
 
         {% highlight javascript %}
@@ -27,11 +27,7 @@ layout: default
         {% endhighlight %}
 
         <div class="content">
-            <p>If you only need a single plugin and have your own method of transpiling the ES6 code you can do the following.</p>
-        </div>
-
-        <div class="notification is-warning">
-            Please do not use this method if you are using more than one plugin. Each singular plugin import sets up the core and triggers the <code>traverseDOM</code> method, that looks through the DOM to find <code>data-bulma</code> attributes.
+            <p>For production I would recommend only including the plugins you need. So, if you need to use Notification and Navbar.</p>
         </div>
 
         {% highlight javascript %}
@@ -48,7 +44,7 @@ layout: default
         </div>
 
         <div class="notification is-warning">
-            This method is not recommended if you are using more than one plugin, as there will be conflicts. It is recommended to instead use the ES6 method to build your own collection.
+            This method is not recommended if you are using more than one plugin, as each independent file has the core packaged with it. It is recommended to instead use the ES6 method to build your own collection.
         </div>
 
         {% highlight html %}

--- a/docs/assets/js/bulmajs/bulma.js
+++ b/docs/assets/js/bulmajs/bulma.js
@@ -60,7 +60,7 @@
 /******/ 	__webpack_require__.p = "";
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 3);
+/******/ 	return __webpack_require__(__webpack_require__.s = 1);
 /******/ })
 /************************************************************************/
 /******/ ([
@@ -73,7 +73,7 @@ var Bulma = {
      * Current BulmaJS version.
      * @type {String}
      */
-    VERSION: '0.1.0',
+    VERSION: '0.2.0',
 
     /**
      * Helper method to create a new plugin.
@@ -119,26 +119,63 @@ var Bulma = {
     }
 };
 
+document.addEventListener('DOMContentLoaded', function (event) {
+    Bulma.traverseDOM();
+});
+
 /* harmony default export */ __webpack_exports__["a"] = (Bulma);
 
 /***/ }),
 /* 1 */
+/***/ (function(module, exports, __webpack_require__) {
+
+module.exports = __webpack_require__(2);
+
+
+/***/ }),
+/* 2 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__core__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__plugins_notification__ = __webpack_require__(3);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__plugins_navbar__ = __webpack_require__(4);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__plugins_message__ = __webpack_require__(5);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__plugins_dropdown__ = __webpack_require__(6);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__plugins_modal__ = __webpack_require__(7);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__plugins_file__ = __webpack_require__(8);
+
+
+
+
+
+
+
+
+window.Bulma = __WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */];
+
+/***/ }),
+/* 3 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__core__ = __webpack_require__(0);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
+
+
 /**
- * Notification module
  * @module Notification
  * @since  0.1.0
  * @author  Thomas Erbe <vizuaalog@gmail.com>
  */
+
 var Notification = function () {
     /**
-     * Module constructor
+     * Plugin constructor
      * @param  {Object} options
      * @return {this}
      */
@@ -394,26 +431,33 @@ var Notification = function () {
     return Notification;
 }();
 
-/* harmony default export */ __webpack_exports__["a"] = (Notification);
+__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('notification', Notification);
+
+/* unused harmony default export */ var _unused_webpack_default_export = (Notification);
 
 /***/ }),
-/* 2 */
+/* 4 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__core__ = __webpack_require__(0);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
+
+
 /**
- * Navbar module
  * @module Navbar
  * @since  0.1.0
  * @author  Thomas Erbe <vizuaalog@gmail.com>
  */
+
 var Navbar = function () {
     /**
-     * Module constructor
+     * Plugin constructor
+     * @param  {Object} options
+     * @return {this}
      */
     function Navbar(options) {
         _classCallCheck(this, Navbar);
@@ -422,8 +466,22 @@ var Navbar = function () {
             throw new Error('[BulmaJS] The navbar component requires an element, trigger and target to function.');
         }
 
-        this.element = options.element;
+        /**
+         * The root navbar element.
+         * @type {HTMLElement}
+         */
+        this.root = options.element;
+
+        /**
+         * The element used for the trigger.
+         * @type {HTMLElement}
+         */
         this.trigger = options.trigger;
+
+        /**
+         * The target element.
+         * @type {HTMLELement}
+         */
         this.target = options.target;
 
         this.registerEvents();
@@ -476,69 +534,31 @@ var Navbar = function () {
     return Navbar;
 }();
 
-/* harmony default export */ __webpack_exports__["a"] = (Navbar);
+__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('navbar', Navbar);
 
-/***/ }),
-/* 3 */
-/***/ (function(module, exports, __webpack_require__) {
-
-module.exports = __webpack_require__(4);
-
-
-/***/ }),
-/* 4 */
-/***/ (function(module, __webpack_exports__, __webpack_require__) {
-
-"use strict";
-Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__core__ = __webpack_require__(0);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__plugins_notification__ = __webpack_require__(1);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__plugins_navbar__ = __webpack_require__(2);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__plugins_message__ = __webpack_require__(5);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__plugins_dropdown__ = __webpack_require__(6);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__plugins_modal__ = __webpack_require__(7);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__plugins_file__ = __webpack_require__(8);
-
-
-
-__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('notification', __WEBPACK_IMPORTED_MODULE_1__plugins_notification__["a" /* default */]);
-
-
-__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('navbar', __WEBPACK_IMPORTED_MODULE_2__plugins_navbar__["a" /* default */]);
-
-
-__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('message', __WEBPACK_IMPORTED_MODULE_3__plugins_message__["a" /* default */]);
-
-
-__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('dropdown', __WEBPACK_IMPORTED_MODULE_4__plugins_dropdown__["a" /* default */]);
-
-
-__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('modal', __WEBPACK_IMPORTED_MODULE_5__plugins_modal__["a" /* default */]);
-
-
-__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('file', __WEBPACK_IMPORTED_MODULE_6__plugins_file__["a" /* default */]);
-
-__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].traverseDOM();
-window.Bulma = __WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */];
+/* unused harmony default export */ var _unused_webpack_default_export = (Navbar);
 
 /***/ }),
 /* 5 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__core__ = __webpack_require__(0);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
+
+
 /**
- * Message module
  * @module Message
  * @since  0.1.0
  * @author  Thomas Erbe <vizuaalog@gmail.com>
  */
+
 var Message = function () {
     /**
-     * Module constructor
+     * Plugin constructor
      * @param  {Object} options
      * @return {this}
      */
@@ -849,26 +869,33 @@ var Message = function () {
     return Message;
 }();
 
-/* harmony default export */ __webpack_exports__["a"] = (Message);
+__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('message', Message);
+
+/* unused harmony default export */ var _unused_webpack_default_export = (Message);
 
 /***/ }),
 /* 6 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__core__ = __webpack_require__(0);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
+
+
 /**
- * Dropdown module
  * @module Dropdown
  * @since  0.1.0
  * @author  Thomas Erbe <vizuaalog@gmail.com>
  */
+
 var Dropdown = function () {
     /**
-     * Module constructor
+     * Plugin constructor
+     * @param  {Object} options
+     * @return {this}
      */
     function Dropdown(options) {
         _classCallCheck(this, Dropdown);
@@ -877,7 +904,16 @@ var Dropdown = function () {
             throw new Error('[BulmaJS] The dropdown component requires an element and trigger to function.');
         }
 
-        this.element = options.element;
+        /**
+         * The root dropdown element.
+         * @type {HTMLElement}
+         */
+        this.root = options.element;
+
+        /**
+         * The element to trigger when clicked.
+         * @type {HTMLElement}
+         */
         this.trigger = options.trigger;
 
         this.registerEvents();
@@ -902,10 +938,10 @@ var Dropdown = function () {
     }, {
         key: 'handleTriggerClick',
         value: function handleTriggerClick(event) {
-            if (this.element.classList.contains('is-active')) {
-                this.element.classList.remove('is-active');
+            if (this.root.classList.contains('is-active')) {
+                this.root.classList.remove('is-active');
             } else {
-                this.element.classList.add('is-active');
+                this.root.classList.add('is-active');
             }
         }
 
@@ -928,164 +964,180 @@ var Dropdown = function () {
     return Dropdown;
 }();
 
-/* harmony default export */ __webpack_exports__["a"] = (Dropdown);
+__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('dropdown', Dropdown);
+
+/* unused harmony default export */ var _unused_webpack_default_export = (Dropdown);
 
 /***/ }),
 /* 7 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__core__ = __webpack_require__(0);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
+
+
 /**
- * Modal module
  * @module Modal
  * @since  0.1.0
  * @author  Thomas Erbe <vizuaalog@gmail.com>
  */
+
 var Modal = function () {
+  /**
+   * Plugin constructor
+   * @param  {Object} options
+   * @return {this}
+   */
+  function Modal(options) {
+    _classCallCheck(this, Modal);
+
+    if (!options) options = {};
+
     /**
-     * Module constructor
-     * @param  {Object} options
-     * @return {this}
+     * Message body text.
+     * @type {string}
      */
-    function Modal(options) {
-        _classCallCheck(this, Modal);
+    this.root = options.hasOwnProperty('element') ? options.element : '';
 
-        if (!options) options = {};
+    /**
+     * The element used to close the message.
+     * @type {HTMLElement}
+     */
+    this.closeButton = this.findCloseButton();
 
-        /**
-         * Message body text.
-         * @type {string}
-         */
-        this.root = options.hasOwnProperty('element') ? options.element : '';
+    this.setupCloseEvent();
+  }
 
-        this.card = options.card ? options.card : false;
+  /**
+   * Helper method used by the Bulma core to create a new instance.
+   * @param  {Object} options
+   * @return {Modal}
+   */
 
-        /**
-         * The element used to close the message.
-         * @type {HTMLElement}
-         */
-        this.closeButton = this.findCloseButton();
 
-        this.setupCloseEvent();
+  _createClass(Modal, [{
+    key: 'open',
+
+
+    /**
+     * Show the message.
+     */
+    value: function open() {
+      this.root.classList.add('is-active');
     }
 
     /**
-     * Helper method used by the Bulma core to create a new instance.
-     * @param  {Object} options
-     * @return {Modal}
+     * Hide the message.
      */
 
+  }, {
+    key: 'close',
+    value: function close() {
+      this.root.classList.remove('is-active');
+    }
 
-    _createClass(Modal, [{
-        key: 'open',
+    /**
+     * Find the close button.
+     * @return {HTMLElement}
+     */
 
+  }, {
+    key: 'findCloseButton',
+    value: function findCloseButton() {
+      var element = this.root.querySelector('.modal-close');
 
-        /**
-         * Show the message.
-         */
-        value: function open() {
-            this.root.classList.add('is-active');
-        }
+      if (!element) {
+        return this.root.querySelector('.delete');
+      }
 
-        /**
-         * Hide the message.
-         */
+      return element;
+    }
 
-    }, {
-        key: 'close',
-        value: function close() {
-            this.root.classList.remove('is-active');
-        }
-    }, {
-        key: 'findCloseButton',
-        value: function findCloseButton() {
-            var element = this.root.querySelector('.modal-close');
+    /**
+     * Setup the event listener for the close button.
+     */
 
-            if (!element) {
-                return this.root.querySelector('.delete');
-            }
+  }, {
+    key: 'setupCloseEvent',
+    value: function setupCloseEvent() {
+      this.closeButton.addEventListener('click', this.handleCloseEvent.bind(this));
+    }
 
-            return element;
-        }
+    /**
+     * Handle the event when our close button is clicked.
+     */
 
-        /**
-         * Setup the event listener for the close button.
-         */
+  }, {
+    key: 'handleCloseEvent',
+    value: function handleCloseEvent() {
+      this.close();
+    }
 
-    }, {
-        key: 'setupCloseEvent',
-        value: function setupCloseEvent() {
-            this.closeButton.addEventListener('click', this.handleCloseEvent.bind(this));
-        }
+    /**
+     * Destroy the message, removing the event listener, interval and element.
+     */
 
-        /**
-         * Handle the event when our close button is clicked.
-         */
+  }, {
+    key: 'destroy',
+    value: function destroy() {
+      if (this.closeButton) {
+        this.closeButton.removeEventListener('click', this.handleCloseEvent.bind(this));
+      }
 
-    }, {
-        key: 'handleCloseEvent',
-        value: function handleCloseEvent() {
-            this.close();
-        }
+      this.root = null;
+      this.closeButton = null;
+    }
 
-        /**
-         * Destroy the message, removing the event listener, interval and element.
-         */
+    /**
+     * Handle parsing the DOMs data attribute API.
+     */
 
-    }, {
-        key: 'destroy',
-        value: function destroy() {
-            if (this.closeButton) {
-                this.closeButton.removeEventListener('click', this.handleCloseEvent.bind(this));
-            }
+  }], [{
+    key: 'create',
+    value: function create(options) {
+      return new Modal(options);
+    }
+  }, {
+    key: 'handleDomParsing',
+    value: function handleDomParsing(element) {
+      return;
+    }
+  }]);
 
-            this.root = null;
-            this.closeButton = null;
-        }
-
-        /**
-         * Handle parsing the DOMs data attribute API.
-         */
-
-    }], [{
-        key: 'create',
-        value: function create(options) {
-            return new Modal(options);
-        }
-    }, {
-        key: 'handleDomParsing',
-        value: function handleDomParsing(element) {
-            return;
-        }
-    }]);
-
-    return Modal;
+  return Modal;
 }();
 
-/* harmony default export */ __webpack_exports__["a"] = (Modal);
+__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('modal', Modal);
+
+/* unused harmony default export */ var _unused_webpack_default_export = (Modal);
 
 /***/ }),
 /* 8 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__core__ = __webpack_require__(0);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
+
+
 /**
- * File module
  * @module File
  * @since  0.1.0
  * @author  Thomas Erbe <vizuaalog@gmail.com>
  */
+
 var File = function () {
     /**
-     * Module constructor
+     * Plugin constructor
+     * @param  {Object} options
+     * @return {this}
      */
     function File(options) {
         _classCallCheck(this, File);
@@ -1094,9 +1146,23 @@ var File = function () {
             throw new Error('[BulmaJS] The file component requires an element to function.');
         }
 
-        this.element = options.element;
-        this.trigger = this.element.querySelector('input');
-        this.target = this.element.querySelector('.file-name');
+        /**
+         * The root file element.
+         * @type {HTMLElement}
+         */
+        this.root = options.element;
+
+        /**
+         * The element to use as the trigger.
+         * @type {HTMLELement}
+         */
+        this.trigger = this.root.querySelector('input');
+
+        /**
+         * The element to show the file name.
+         * @type {HTMLElement}
+         */
+        this.target = this.root.querySelector('.file-name');
 
         this.registerEvents();
     }
@@ -1132,11 +1198,22 @@ var File = function () {
                 this.setFileName(event.target.files.length + ' files');
             }
         }
+
+        /**
+         * Clear the file name element.
+         */
+
     }, {
         key: 'clearFileName',
         value: function clearFileName() {
             this.target.innerHTML = '';
         }
+
+        /**
+         * Set the text for the file name element.
+         * @param {string} value
+         */
+
     }, {
         key: 'setFileName',
         value: function setFileName(value) {
@@ -1159,7 +1236,9 @@ var File = function () {
     return File;
 }();
 
-/* harmony default export */ __webpack_exports__["a"] = (File);
+__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('file', File);
+
+/* unused harmony default export */ var _unused_webpack_default_export = (File);
 
 /***/ })
 /******/ ]);

--- a/docs/assets/js/bulmajs/dropdown.js
+++ b/docs/assets/js/bulmajs/dropdown.js
@@ -60,11 +60,12 @@
 /******/ 	__webpack_require__.p = "";
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 11);
+/******/ 	return __webpack_require__(__webpack_require__.s = 13);
 /******/ })
 /************************************************************************/
-/******/ ([
-/* 0 */
+/******/ ({
+
+/***/ 0:
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -126,8 +127,32 @@ document.addEventListener('DOMContentLoaded', function (event) {
 /* harmony default export */ __webpack_exports__["a"] = (Bulma);
 
 /***/ }),
-/* 1 */,
-/* 2 */
+
+/***/ 13:
+/***/ (function(module, exports, __webpack_require__) {
+
+module.exports = __webpack_require__(14);
+
+
+/***/ }),
+
+/***/ 14:
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__core__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__plugins_dropdown__ = __webpack_require__(4);
+
+
+__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('dropdown', __WEBPACK_IMPORTED_MODULE_1__plugins_dropdown__["a" /* default */]);
+
+__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].traverseDOM();
+window.Bulma = __WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */];
+
+/***/ }),
+
+/***/ 4:
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -139,41 +164,35 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 
 /**
- * @module Navbar
+ * @module Dropdown
  * @since  0.1.0
  * @author  Thomas Erbe <vizuaalog@gmail.com>
  */
 
-var Navbar = function () {
+var Dropdown = function () {
     /**
      * Plugin constructor
      * @param  {Object} options
      * @return {this}
      */
-    function Navbar(options) {
-        _classCallCheck(this, Navbar);
+    function Dropdown(options) {
+        _classCallCheck(this, Dropdown);
 
-        if (!options.element || !options.trigger || !options.target) {
-            throw new Error('[BulmaJS] The navbar component requires an element, trigger and target to function.');
+        if (!options.element || !options.trigger) {
+            throw new Error('[BulmaJS] The dropdown component requires an element and trigger to function.');
         }
 
         /**
-         * The root navbar element.
+         * The root dropdown element.
          * @type {HTMLElement}
          */
         this.root = options.element;
 
         /**
-         * The element used for the trigger.
+         * The element to trigger when clicked.
          * @type {HTMLElement}
          */
         this.trigger = options.trigger;
-
-        /**
-         * The target element.
-         * @type {HTMLELement}
-         */
-        this.target = options.target;
 
         this.registerEvents();
     }
@@ -183,7 +202,7 @@ var Navbar = function () {
      */
 
 
-    _createClass(Navbar, [{
+    _createClass(Dropdown, [{
         key: 'registerEvents',
         value: function registerEvents() {
             this.trigger.addEventListener('click', this.handleTriggerClick.bind(this));
@@ -197,10 +216,10 @@ var Navbar = function () {
     }, {
         key: 'handleTriggerClick',
         value: function handleTriggerClick(event) {
-            if (this.target.classList.contains('is-active')) {
-                this.target.classList.remove('is-active');
+            if (this.root.classList.contains('is-active')) {
+                this.root.classList.remove('is-active');
             } else {
-                this.target.classList.add('is-active');
+                this.root.classList.add('is-active');
             }
         }
 
@@ -211,53 +230,22 @@ var Navbar = function () {
     }], [{
         key: 'handleDomParsing',
         value: function handleDomParsing(element) {
-            var trigger = element.querySelector('[data-trigger]'),
-                target = trigger.getAttribute('data-target');
+            var trigger = element.querySelector('[data-trigger]');
 
-            new Navbar({
+            new Dropdown({
                 element: element,
-                trigger: trigger,
-                target: element.querySelector('#' + target)
+                trigger: trigger
             });
         }
     }]);
 
-    return Navbar;
+    return Dropdown;
 }();
 
-__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('navbar', Navbar);
+__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('dropdown', Dropdown);
 
-/* harmony default export */ __webpack_exports__["a"] = (Navbar);
-
-/***/ }),
-/* 3 */,
-/* 4 */,
-/* 5 */,
-/* 6 */,
-/* 7 */,
-/* 8 */,
-/* 9 */,
-/* 10 */,
-/* 11 */
-/***/ (function(module, exports, __webpack_require__) {
-
-module.exports = __webpack_require__(12);
-
-
-/***/ }),
-/* 12 */
-/***/ (function(module, __webpack_exports__, __webpack_require__) {
-
-"use strict";
-Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__core__ = __webpack_require__(0);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__plugins_navbar__ = __webpack_require__(2);
-
-
-__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('navbar', __WEBPACK_IMPORTED_MODULE_1__plugins_navbar__["a" /* default */]);
-
-__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].traverseDOM();
-window.Bulma = __WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */];
+/* harmony default export */ __webpack_exports__["a"] = (Dropdown);
 
 /***/ })
-/******/ ]);
+
+/******/ });

--- a/docs/assets/js/bulmajs/file.js
+++ b/docs/assets/js/bulmajs/file.js
@@ -60,11 +60,12 @@
 /******/ 	__webpack_require__.p = "";
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 11);
+/******/ 	return __webpack_require__(__webpack_require__.s = 15);
 /******/ })
 /************************************************************************/
-/******/ ([
-/* 0 */
+/******/ ({
+
+/***/ 0:
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -126,8 +127,32 @@ document.addEventListener('DOMContentLoaded', function (event) {
 /* harmony default export */ __webpack_exports__["a"] = (Bulma);
 
 /***/ }),
-/* 1 */,
-/* 2 */
+
+/***/ 15:
+/***/ (function(module, exports, __webpack_require__) {
+
+module.exports = __webpack_require__(16);
+
+
+/***/ }),
+
+/***/ 16:
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__core__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__plugins_file__ = __webpack_require__(6);
+
+
+__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('file', __WEBPACK_IMPORTED_MODULE_1__plugins_file__["a" /* default */]);
+
+__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].traverseDOM();
+window.Bulma = __WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */];
+
+/***/ }),
+
+/***/ 6:
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -139,41 +164,41 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 
 /**
- * @module Navbar
+ * @module File
  * @since  0.1.0
  * @author  Thomas Erbe <vizuaalog@gmail.com>
  */
 
-var Navbar = function () {
+var File = function () {
     /**
      * Plugin constructor
      * @param  {Object} options
      * @return {this}
      */
-    function Navbar(options) {
-        _classCallCheck(this, Navbar);
+    function File(options) {
+        _classCallCheck(this, File);
 
-        if (!options.element || !options.trigger || !options.target) {
-            throw new Error('[BulmaJS] The navbar component requires an element, trigger and target to function.');
+        if (!options.element) {
+            throw new Error('[BulmaJS] The file component requires an element to function.');
         }
 
         /**
-         * The root navbar element.
+         * The root file element.
          * @type {HTMLElement}
          */
         this.root = options.element;
 
         /**
-         * The element used for the trigger.
-         * @type {HTMLElement}
-         */
-        this.trigger = options.trigger;
-
-        /**
-         * The target element.
+         * The element to use as the trigger.
          * @type {HTMLELement}
          */
-        this.target = options.target;
+        this.trigger = this.root.querySelector('input');
+
+        /**
+         * The element to show the file name.
+         * @type {HTMLElement}
+         */
+        this.target = this.root.querySelector('.file-name');
 
         this.registerEvents();
     }
@@ -183,10 +208,10 @@ var Navbar = function () {
      */
 
 
-    _createClass(Navbar, [{
+    _createClass(File, [{
         key: 'registerEvents',
         value: function registerEvents() {
-            this.trigger.addEventListener('click', this.handleTriggerClick.bind(this));
+            this.trigger.addEventListener('change', this.handleTriggerChange.bind(this));
         }
 
         /**
@@ -195,13 +220,40 @@ var Navbar = function () {
          */
 
     }, {
-        key: 'handleTriggerClick',
-        value: function handleTriggerClick(event) {
-            if (this.target.classList.contains('is-active')) {
-                this.target.classList.remove('is-active');
-            } else {
-                this.target.classList.add('is-active');
+        key: 'handleTriggerChange',
+        value: function handleTriggerChange(event) {
+            if (event.target.files.length === 0) {
+                this.clearFileName();
             }
+
+            if (event.target.files.length === 1) {
+                this.setFileName(event.target.files[0].name);
+            }
+
+            if (event.target.files.length > 1) {
+                this.setFileName(event.target.files.length + ' files');
+            }
+        }
+
+        /**
+         * Clear the file name element.
+         */
+
+    }, {
+        key: 'clearFileName',
+        value: function clearFileName() {
+            this.target.innerHTML = '';
+        }
+
+        /**
+         * Set the text for the file name element.
+         * @param {string} value
+         */
+
+    }, {
+        key: 'setFileName',
+        value: function setFileName(value) {
+            this.target.innerHTML = value;
         }
 
         /**
@@ -211,53 +263,19 @@ var Navbar = function () {
     }], [{
         key: 'handleDomParsing',
         value: function handleDomParsing(element) {
-            var trigger = element.querySelector('[data-trigger]'),
-                target = trigger.getAttribute('data-target');
-
-            new Navbar({
-                element: element,
-                trigger: trigger,
-                target: element.querySelector('#' + target)
+            new File({
+                element: element
             });
         }
     }]);
 
-    return Navbar;
+    return File;
 }();
 
-__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('navbar', Navbar);
+__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('file', File);
 
-/* harmony default export */ __webpack_exports__["a"] = (Navbar);
-
-/***/ }),
-/* 3 */,
-/* 4 */,
-/* 5 */,
-/* 6 */,
-/* 7 */,
-/* 8 */,
-/* 9 */,
-/* 10 */,
-/* 11 */
-/***/ (function(module, exports, __webpack_require__) {
-
-module.exports = __webpack_require__(12);
-
-
-/***/ }),
-/* 12 */
-/***/ (function(module, __webpack_exports__, __webpack_require__) {
-
-"use strict";
-Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__core__ = __webpack_require__(0);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__plugins_navbar__ = __webpack_require__(2);
-
-
-__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('navbar', __WEBPACK_IMPORTED_MODULE_1__plugins_navbar__["a" /* default */]);
-
-__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].traverseDOM();
-window.Bulma = __WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */];
+/* harmony default export */ __webpack_exports__["a"] = (File);
 
 /***/ })
-/******/ ]);
+
+/******/ });

--- a/docs/assets/js/bulmajs/message.js
+++ b/docs/assets/js/bulmajs/message.js
@@ -60,11 +60,12 @@
 /******/ 	__webpack_require__.p = "";
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 9);
+/******/ 	return __webpack_require__(__webpack_require__.s = 17);
 /******/ })
 /************************************************************************/
-/******/ ([
-/* 0 */
+/******/ ({
+
+/***/ 0:
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -126,7 +127,32 @@ document.addEventListener('DOMContentLoaded', function (event) {
 /* harmony default export */ __webpack_exports__["a"] = (Bulma);
 
 /***/ }),
-/* 1 */
+
+/***/ 17:
+/***/ (function(module, exports, __webpack_require__) {
+
+module.exports = __webpack_require__(18);
+
+
+/***/ }),
+
+/***/ 18:
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__core__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__plugins_message__ = __webpack_require__(3);
+
+
+__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('message', __WEBPACK_IMPORTED_MODULE_1__plugins_message__["a" /* default */]);
+
+__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].traverseDOM();
+window.Bulma = __WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */];
+
+/***/ }),
+
+/***/ 3:
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -138,72 +164,88 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 
 /**
- * @module Notification
+ * @module Message
  * @since  0.1.0
  * @author  Thomas Erbe <vizuaalog@gmail.com>
  */
 
-var Notification = function () {
+var Message = function () {
     /**
      * Plugin constructor
      * @param  {Object} options
      * @return {this}
      */
-    function Notification(options) {
-        _classCallCheck(this, Notification);
+    function Message(options) {
+        _classCallCheck(this, Message);
 
         if (!options) options = {};
 
         /**
-         * Notifications body text.
+         * Message body text.
          * @type {string}
          */
         this.body = options.hasOwnProperty('body') ? options.body : '';
 
         /**
-         * The parent element to inject notification
+         * The parent element to inject message
          */
         this.parent = options.hasOwnProperty('parent') ? options.parent : document.body;
 
         /**
-         * Notifications color modifier.
+         * Message color modifier.
          * @type {string} Possible values are null, primary, info, success, warning, danger
          */
         this.color = options.hasOwnProperty('color') ? options.color : '';
 
         /**
-         * How long to wait before auto dismissing the notification.
-         * @type {int|null} If null notification must be dismissed manually.
+         * How long to wait before auto dismissing the message.
+         * @type {int|null} If null message must be dismissed manually.
          */
         this.dismissInterval = options.hasOwnProperty('dismissInterval') ? this.createDismissInterval(options.dismissInterval) : null;
 
         /**
-         * Does this notification had a dismiss button?
+         * Does this message had a dismiss button?
          * @type {Boolean}
          */
         this.isDismissable = options.hasOwnProperty('isDismissable') ? options.isDismissable : false;
 
         /**
-         * Should this notification be destroyed when it is dismissed.
+         * Should this message be destroyed when it is dismissed.
          * @type {Boolean}
          */
         this.destroyOnDismiss = options.hasOwnProperty('destroyOnDismiss') ? options.destroyOnDismiss : true;
 
         /**
-         * The root notification element.
-         * @type {HTMLElement|null} If this is not provided a new notification element will be created.
+         * The root message element.
+         * @type {HTMLElement|null} If this is not provided a new message element will be created.
          */
         this.root = options.hasOwnProperty('element') ? options.element : null;
 
         /**
-         * The element used to close the notification.
+         * The element used to close the message.
          * @type {HTMLElement}
          */
         this.closeButton = options.hasOwnProperty('closeButton') ? options.closeButton : this.createCloseButton();
 
+        /**
+         * The size of the message
+         * @type {String} Possible values are small, normal, medium or large
+         */
+        this.size = options.hasOwnProperty('size') ? options.size : '';
+
+        /**
+         * The title of the message
+         * @type {String}
+         */
+        this.title = options.hasOwnProperty('title') ? options.title : '';
+
         if (!this.root) {
             this.createRootElement();
             this.parent.appendChild(this.root);
+        }
+
+        if (this.title) {
+            this.createMessageHeader();
         }
 
         if (this.body) {
@@ -221,31 +263,52 @@ var Notification = function () {
         if (this.color) {
             this.setColor();
         }
+
+        if (this.size) {
+            this.setSize();
+        }
     }
 
     /**
      * Helper method used by the Bulma core to create a new instance.
      * @param  {Object} options
-     * @return {Notification}
+     * @return {Message}
      */
 
 
-    _createClass(Notification, [{
+    _createClass(Message, [{
         key: 'createRootElement',
 
 
         /**
-         * Create the main notification element.
+         * Create the main message element.
          */
         value: function createRootElement() {
             this.root = document.createElement('div');
+            this.root.classList.add('message');
 
-            this.root.classList.add('notification');
             this.hide();
         }
 
         /**
-         * Show the notification.
+         * Create the message header
+         */
+
+    }, {
+        key: 'createMessageHeader',
+        value: function createMessageHeader() {
+            var header = document.createElement('div');
+            header.classList.add('message-header');
+
+            header.innerHTML = '<p>' + this.title + '</p>';
+
+            this.title = header;
+
+            this.root.insertBefore(this.title, this.root.firstChild);
+        }
+
+        /**
+         * Show the message.
          */
 
     }, {
@@ -255,7 +318,7 @@ var Notification = function () {
         }
 
         /**
-         * Hide the notification.
+         * Hide the message.
          */
 
     }, {
@@ -265,17 +328,21 @@ var Notification = function () {
         }
 
         /**
-         * Insert the body text into the notification.
+         * Insert the body text into the message.
          */
 
     }, {
         key: 'insertBody',
         value: function insertBody() {
-            this.root.innerHTML = this.body;
+            var body = document.createElement('div');
+            body.classList.add('message-body');
+            body.innerHTML = this.body;
+
+            this.root.appendChild(body);
         }
 
         /**
-         * Set the colour of the notification.
+         * Set the colour of the message.
          */
 
     }, {
@@ -285,7 +352,17 @@ var Notification = function () {
         }
 
         /**
-         * Create the element that will be used to close the notification.
+         * Set the size of the message.
+         */
+
+    }, {
+        key: 'setSize',
+        value: function setSize() {
+            this.root.classList.add('is-' + this.size);
+        }
+
+        /**
+         * Create the element that will be used to close the message.
          * @return {HTMLElement}
          */
 
@@ -300,7 +377,7 @@ var Notification = function () {
         }
 
         /**
-         * Create an interval to dismiss the notification after the set number of ms.
+         * Create an interval to dismiss the message after the set number of ms.
          * @param  {int}
          */
 
@@ -321,7 +398,11 @@ var Notification = function () {
     }, {
         key: 'prependCloseButton',
         value: function prependCloseButton() {
-            this.root.insertBefore(this.closeButton, this.root.firstChild);
+            if (!this.title) {
+                this.createMessageHeader();
+            }
+
+            this.title.appendChild(this.closeButton);
         }
 
         /**
@@ -349,7 +430,7 @@ var Notification = function () {
         }
 
         /**
-         * Destroy the notification, removing the event listener, interval and element.
+         * Destroy the message, removing the event listener, interval and element.
          */
 
     }, {
@@ -373,7 +454,7 @@ var Notification = function () {
     }], [{
         key: 'create',
         value: function create(options) {
-            return new Notification(options);
+            return new Message(options);
         }
     }, {
         key: 'handleDomParsing',
@@ -394,45 +475,17 @@ var Notification = function () {
                 options['dismissInterval'] = parseInt(dismissInterval);
             }
 
-            new Notification(options);
+            new Message(options);
         }
     }]);
 
-    return Notification;
+    return Message;
 }();
 
-__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('notification', Notification);
+__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('message', Message);
 
-/* harmony default export */ __webpack_exports__["a"] = (Notification);
-
-/***/ }),
-/* 2 */,
-/* 3 */,
-/* 4 */,
-/* 5 */,
-/* 6 */,
-/* 7 */,
-/* 8 */,
-/* 9 */
-/***/ (function(module, exports, __webpack_require__) {
-
-module.exports = __webpack_require__(10);
-
-
-/***/ }),
-/* 10 */
-/***/ (function(module, __webpack_exports__, __webpack_require__) {
-
-"use strict";
-Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__core__ = __webpack_require__(0);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__plugins_notification__ = __webpack_require__(1);
-
-
-__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('notification', __WEBPACK_IMPORTED_MODULE_1__plugins_notification__["a" /* default */]);
-
-__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].traverseDOM();
-window.Bulma = __WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */];
+/* harmony default export */ __webpack_exports__["a"] = (Message);
 
 /***/ })
-/******/ ]);
+
+/******/ });

--- a/docs/assets/js/bulmajs/modal.js
+++ b/docs/assets/js/bulmajs/modal.js
@@ -60,11 +60,12 @@
 /******/ 	__webpack_require__.p = "";
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 11);
+/******/ 	return __webpack_require__(__webpack_require__.s = 19);
 /******/ })
 /************************************************************************/
-/******/ ([
-/* 0 */
+/******/ ({
+
+/***/ 0:
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -126,8 +127,32 @@ document.addEventListener('DOMContentLoaded', function (event) {
 /* harmony default export */ __webpack_exports__["a"] = (Bulma);
 
 /***/ }),
-/* 1 */,
-/* 2 */
+
+/***/ 19:
+/***/ (function(module, exports, __webpack_require__) {
+
+module.exports = __webpack_require__(20);
+
+
+/***/ }),
+
+/***/ 20:
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__core__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__plugins_modal__ = __webpack_require__(5);
+
+
+__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('modal', __WEBPACK_IMPORTED_MODULE_1__plugins_modal__["a" /* default */]);
+
+__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].traverseDOM();
+window.Bulma = __WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */];
+
+/***/ }),
+
+/***/ 5:
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -139,125 +164,140 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 
 /**
- * @module Navbar
+ * @module Modal
  * @since  0.1.0
  * @author  Thomas Erbe <vizuaalog@gmail.com>
  */
 
-var Navbar = function () {
+var Modal = function () {
+  /**
+   * Plugin constructor
+   * @param  {Object} options
+   * @return {this}
+   */
+  function Modal(options) {
+    _classCallCheck(this, Modal);
+
+    if (!options) options = {};
+
     /**
-     * Plugin constructor
-     * @param  {Object} options
-     * @return {this}
+     * Message body text.
+     * @type {string}
      */
-    function Navbar(options) {
-        _classCallCheck(this, Navbar);
+    this.root = options.hasOwnProperty('element') ? options.element : '';
 
-        if (!options.element || !options.trigger || !options.target) {
-            throw new Error('[BulmaJS] The navbar component requires an element, trigger and target to function.');
-        }
+    /**
+     * The element used to close the message.
+     * @type {HTMLElement}
+     */
+    this.closeButton = this.findCloseButton();
 
-        /**
-         * The root navbar element.
-         * @type {HTMLElement}
-         */
-        this.root = options.element;
+    this.setupCloseEvent();
+  }
 
-        /**
-         * The element used for the trigger.
-         * @type {HTMLElement}
-         */
-        this.trigger = options.trigger;
+  /**
+   * Helper method used by the Bulma core to create a new instance.
+   * @param  {Object} options
+   * @return {Modal}
+   */
 
-        /**
-         * The target element.
-         * @type {HTMLELement}
-         */
-        this.target = options.target;
 
-        this.registerEvents();
+  _createClass(Modal, [{
+    key: 'open',
+
+
+    /**
+     * Show the message.
+     */
+    value: function open() {
+      this.root.classList.add('is-active');
     }
 
     /**
-     * Register all the events this module needs.
+     * Hide the message.
      */
 
+  }, {
+    key: 'close',
+    value: function close() {
+      this.root.classList.remove('is-active');
+    }
 
-    _createClass(Navbar, [{
-        key: 'registerEvents',
-        value: function registerEvents() {
-            this.trigger.addEventListener('click', this.handleTriggerClick.bind(this));
-        }
+    /**
+     * Find the close button.
+     * @return {HTMLElement}
+     */
 
-        /**
-         * Handle the click event on the trigger.
-         * @param  {Object} event
-         */
+  }, {
+    key: 'findCloseButton',
+    value: function findCloseButton() {
+      var element = this.root.querySelector('.modal-close');
 
-    }, {
-        key: 'handleTriggerClick',
-        value: function handleTriggerClick(event) {
-            if (this.target.classList.contains('is-active')) {
-                this.target.classList.remove('is-active');
-            } else {
-                this.target.classList.add('is-active');
-            }
-        }
+      if (!element) {
+        return this.root.querySelector('.delete');
+      }
 
-        /**
-         * Handle parsing the DOMs data attribute API.
-         */
+      return element;
+    }
 
-    }], [{
-        key: 'handleDomParsing',
-        value: function handleDomParsing(element) {
-            var trigger = element.querySelector('[data-trigger]'),
-                target = trigger.getAttribute('data-target');
+    /**
+     * Setup the event listener for the close button.
+     */
 
-            new Navbar({
-                element: element,
-                trigger: trigger,
-                target: element.querySelector('#' + target)
-            });
-        }
-    }]);
+  }, {
+    key: 'setupCloseEvent',
+    value: function setupCloseEvent() {
+      this.closeButton.addEventListener('click', this.handleCloseEvent.bind(this));
+    }
 
-    return Navbar;
+    /**
+     * Handle the event when our close button is clicked.
+     */
+
+  }, {
+    key: 'handleCloseEvent',
+    value: function handleCloseEvent() {
+      this.close();
+    }
+
+    /**
+     * Destroy the message, removing the event listener, interval and element.
+     */
+
+  }, {
+    key: 'destroy',
+    value: function destroy() {
+      if (this.closeButton) {
+        this.closeButton.removeEventListener('click', this.handleCloseEvent.bind(this));
+      }
+
+      this.root = null;
+      this.closeButton = null;
+    }
+
+    /**
+     * Handle parsing the DOMs data attribute API.
+     */
+
+  }], [{
+    key: 'create',
+    value: function create(options) {
+      return new Modal(options);
+    }
+  }, {
+    key: 'handleDomParsing',
+    value: function handleDomParsing(element) {
+      return;
+    }
+  }]);
+
+  return Modal;
 }();
 
-__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('navbar', Navbar);
+__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('modal', Modal);
 
-/* harmony default export */ __webpack_exports__["a"] = (Navbar);
-
-/***/ }),
-/* 3 */,
-/* 4 */,
-/* 5 */,
-/* 6 */,
-/* 7 */,
-/* 8 */,
-/* 9 */,
-/* 10 */,
-/* 11 */
-/***/ (function(module, exports, __webpack_require__) {
-
-module.exports = __webpack_require__(12);
-
-
-/***/ }),
-/* 12 */
-/***/ (function(module, __webpack_exports__, __webpack_require__) {
-
-"use strict";
-Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__core__ = __webpack_require__(0);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__plugins_navbar__ = __webpack_require__(2);
-
-
-__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].registerPlugin('navbar', __WEBPACK_IMPORTED_MODULE_1__plugins_navbar__["a" /* default */]);
-
-__WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */].traverseDOM();
-window.Bulma = __WEBPACK_IMPORTED_MODULE_0__core__["a" /* default */];
+/* harmony default export */ __webpack_exports__["a"] = (Modal);
 
 /***/ })
-/******/ ]);
+
+/******/ });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bulmajs",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Unofficial javascript extension to the awesome Bulma CSS framework.",
   "main": "src/bulma.js",
   "author": "Thomas Erbe <vizuaalog@gmail.com>",

--- a/src/bulma.js
+++ b/src/bulma.js
@@ -1,22 +1,9 @@
 import Bulma from './core';
-
 import Notification from './plugins/notification';
-Bulma.registerPlugin('notification', Notification);
-
 import Navbar from './plugins/navbar';
-Bulma.registerPlugin('navbar', Navbar);
-
 import Message from './plugins/message';
-Bulma.registerPlugin('message', Message);
-
 import Dropdown from './plugins/dropdown';
-Bulma.registerPlugin('dropdown', Dropdown);
-
 import Modal from './plugins/modal';
-Bulma.registerPlugin('modal', Modal);
-
 import File from './plugins/file';
-Bulma.registerPlugin('file', File);
 
-Bulma.traverseDOM();
 window.Bulma = Bulma;

--- a/src/core.js
+++ b/src/core.js
@@ -3,7 +3,7 @@ const Bulma = {
      * Current BulmaJS version.
      * @type {String}
      */
-    VERSION: '0.1.0',
+    VERSION: '0.2.0',
 
     /**
      * Helper method to create a new plugin.

--- a/src/core.js
+++ b/src/core.js
@@ -49,4 +49,8 @@ const Bulma = {
     }
 }
 
+document.addEventListener('DOMContentLoaded', (event) => {
+    Bulma.traverseDOM();
+});
+
 export default Bulma;

--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -1,6 +1,0 @@
-import Bulma from './core';
-import Dropdown from './plugins/dropdown';
-Bulma.registerPlugin('dropdown', Dropdown);
-
-Bulma.traverseDOM();
-window.Bulma = Bulma;

--- a/src/file.js
+++ b/src/file.js
@@ -1,6 +1,0 @@
-import Bulma from './core';
-import File from './plugins/file';
-Bulma.registerPlugin('file', File);
-
-Bulma.traverseDOM();
-window.Bulma = Bulma;

--- a/src/message.js
+++ b/src/message.js
@@ -1,6 +1,0 @@
-import Bulma from './core';
-import Message from './plugins/message';
-Bulma.registerPlugin('message', Message);
-
-Bulma.traverseDOM();
-window.Bulma = Bulma;

--- a/src/modal.js
+++ b/src/modal.js
@@ -1,6 +1,0 @@
-import Bulma from './core';
-import Modal from './plugins/modal';
-Bulma.registerPlugin('modal', Modal);
-
-Bulma.traverseDOM();
-window.Bulma = Bulma;

--- a/src/navbar.js
+++ b/src/navbar.js
@@ -1,6 +1,0 @@
-import Bulma from './core';
-import Navbar from './plugins/navbar';
-Bulma.registerPlugin('navbar', Navbar);
-
-Bulma.traverseDOM();
-window.Bulma = Bulma;

--- a/src/notification.js
+++ b/src/notification.js
@@ -1,6 +1,0 @@
-import Bulma from './core';
-import Notification from './plugins/notification';
-Bulma.registerPlugin('notification', Notification);
-
-Bulma.traverseDOM();
-window.Bulma = Bulma;

--- a/src/plugins/dropdown.js
+++ b/src/plugins/dropdown.js
@@ -1,3 +1,5 @@
+import Bulma from '../core';
+
 /**
  * @module Dropdown
  * @since  0.1.0
@@ -60,5 +62,7 @@ class Dropdown {
         });
     }
 }
+
+Bulma.registerPlugin('dropdown', Dropdown);
 
 export default Dropdown;

--- a/src/plugins/file.js
+++ b/src/plugins/file.js
@@ -1,3 +1,5 @@
+import Bulma from '../core';
+
 /**
  * @module File
  * @since  0.1.0
@@ -84,5 +86,7 @@ class File {
         });
     }
 }
+
+Bulma.registerPlugin('file', File);
 
 export default File;

--- a/src/plugins/message.js
+++ b/src/plugins/message.js
@@ -1,3 +1,5 @@
+import Bulma from '../core';
+
 /**
  * @module Message
  * @since  0.1.0
@@ -262,5 +264,7 @@ class Message {
         new Message(options);
     }
 }
+
+Bulma.registerPlugin('message', Message);
 
 export default Message;

--- a/src/plugins/modal.js
+++ b/src/plugins/modal.js
@@ -1,3 +1,5 @@
+import Bulma from '../core';
+
 /**
  * @module Modal
  * @since  0.1.0
@@ -97,5 +99,7 @@ class Modal {
         return;
     }
 }
+
+Bulma.registerPlugin('modal', Modal);
 
 export default Modal;

--- a/src/plugins/navbar.js
+++ b/src/plugins/navbar.js
@@ -1,3 +1,5 @@
+import Bulma from '../core';
+
 /**
  * @module Navbar
  * @since  0.1.0
@@ -68,5 +70,7 @@ class Navbar {
         });
     }
 }
+
+Bulma.registerPlugin('navbar', Navbar);
 
 export default Navbar;

--- a/src/plugins/notification.js
+++ b/src/plugins/notification.js
@@ -1,3 +1,5 @@
+import Bulma from '../core';
+
 /**
  * @module Notification
  * @since  0.1.0
@@ -213,5 +215,7 @@ class Notification {
         new Notification(options);
     }
 }
+
+Bulma.registerPlugin('notification', Notification);
 
 export default Notification;

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -1,4 +1,6 @@
 let mix = require('laravel-mix');
+let path = require('path');
+let fs = require('fs');
 
 /*
  |--------------------------------------------------------------------------
@@ -11,10 +13,15 @@ let mix = require('laravel-mix');
  |
  */
 
-mix.js('src/bulma.js', 'dist/bulma.js')
-    .js('src/notification.js', 'dist/')
-    .js('src/navbar.js', 'dist/')
-    .js('src/dropdown.js', 'dist/')
-    .js('src/file.js', 'dist/')
-    .js('src/message.js', 'dist/')
-    .js('src/modal.js', 'dist/');
+mix.js('src/bulma.js', 'dist/bulma.js');
+
+fs.readdir('./src/plugins', (err, files) => {
+    if(err) {
+        console.error( "Could not list the directory.", err );
+        process.exit( 1 );
+    }
+
+    files.forEach((file, index) => {
+        mix.js(path.join('./src/plugins', file), 'dist/');
+    });
+});


### PR DESCRIPTION
* Refactor how the plugins are registered/work to allow for a much simpler way of using the library.
* Update the build process to loop over the plugins dir for each single plugin, this prevents the need for each new plugin to also be added to the build config.