### PR TITLE
Fix case of module file name in docs

### DIFF
--- a/docs/_includes/code/import-singular.js
+++ b/docs/_includes/code/import-singular.js
@@ -1,6 +1,6 @@
 // Import BulmaJS plugin
-import Notification from 'path/to/bulmajs/src/plugins/Notification';
-import Navbar from 'path/to/bulmajs/src/plugins/Navbar';
+import Notification from 'path/to/bulmajs/src/plugins/notification';
+import Navbar from 'path/to/bulmajs/src/plugins/navbar';
 
 // Everything is now setup. One document ready the DOM will be parsed.
 // If you would like to register a Bulma global, you can import Bulma


### PR DESCRIPTION
Documentation shows module file name capitalized, when the file is actually lowercase. This works fine on a case-insensitive system like a Mac, but not on a case-sensitive system like Linux. This means that the module will not be found if you use a capitalized filename.

Note that I'm also not sure why the full path to the module is shown; it doesn't seem to be necessary. I've not changed that, though, as this isn't an area I'm deeply familiar with.

Props to support at Netlify for helping to diagnose this.