### PR TITLE
adding optional close button binding

### DIFF
--- a/dist/bulma.js
+++ b/dist/bulma.js
@@ -893,12 +893,20 @@ var Modal = function () {
     this.root = options.hasOwnProperty('element') ? options.element : '';
 
     /**
+     * Closable toggle switch.
+     * @type {bool}
+     */
+    this.closable = options.hasOwnProperty('closable') ? options.closable : true;
+    console.log(this);
+    /**
      * The element used to close the message.
      * @type {HTMLElement}
      */
     this.closeButton = this.findCloseButton();
 
-    if (this.closeButton || options.hasOwnProperty('closable') && options.closable) this.setupCloseEvent();
+    if (this.closeButton && this.closable) {
+      this.setupCloseEvent();
+    }
   }
 
   /**

--- a/dist/bulma.js
+++ b/dist/bulma.js
@@ -898,7 +898,7 @@ var Modal = function () {
      */
     this.closeButton = this.findCloseButton();
 
-    this.setupCloseEvent();
+    if (this.closeButton || options.hasOwnProperty('closable') && options.closable) this.setupCloseEvent();
   }
 
   /**

--- a/dist/modal.js
+++ b/dist/modal.js
@@ -202,7 +202,7 @@ var Modal = function () {
      */
     this.closeButton = this.findCloseButton();
 
-    this.setupCloseEvent();
+    if (this.closeButton || options.hasOwnProperty('closable') && options.closable) this.setupCloseEvent();
   }
 
   /**

--- a/dist/modal.js
+++ b/dist/modal.js
@@ -197,12 +197,20 @@ var Modal = function () {
     this.root = options.hasOwnProperty('element') ? options.element : '';
 
     /**
+     * Closable toggle switch.
+     * @type {bool}
+     */
+    this.closable = options.hasOwnProperty('closable') ? options.closable : true;
+    console.log(this);
+    /**
      * The element used to close the message.
      * @type {HTMLElement}
      */
     this.closeButton = this.findCloseButton();
 
-    if (this.closeButton || options.hasOwnProperty('closable') && options.closable) this.setupCloseEvent();
+    if (this.closeButton && this.closable) {
+      this.setupCloseEvent();
+    }
   }
 
   /**

--- a/src/plugins/modal.js
+++ b/src/plugins/modal.js
@@ -21,13 +21,20 @@ class Modal {
         this.root = options.hasOwnProperty('element') ? options.element : '';
 
         /**
+         * Closable toggle switch.
+         * @type {bool}
+         */
+        this.closable = options.hasOwnProperty('closable') ? options.closable : true ;
+
+        /**
          * The element used to close the message.
          * @type {HTMLElement}
          */
         this.closeButton = this.findCloseButton();
 
-        if(this.closeButton || (options.hasOwnProperty('closable') && options.closable))
+        if(this.closeButton || this.closable ) {
             this.setupCloseEvent();
+        }
     }
 
     /**

--- a/src/plugins/modal.js
+++ b/src/plugins/modal.js
@@ -26,7 +26,8 @@ class Modal {
          */
         this.closeButton = this.findCloseButton();
 
-        this.setupCloseEvent();
+        if(this.closeButton || (options.hasOwnProperty('closable') && options.closable))
+            this.setupCloseEvent();
     }
 
     /**

--- a/src/plugins/modal.js
+++ b/src/plugins/modal.js
@@ -32,7 +32,7 @@ class Modal {
          */
         this.closeButton = this.findCloseButton();
 
-        if(this.closeButton || this.closable ) {
+        if(this.closeButton && this.closable ) {
             this.setupCloseEvent();
         }
     }
@@ -92,7 +92,7 @@ class Modal {
      * Destroy the message, removing the event listener, interval and element.
      */
     destroy() {
-        if(this.closeButton) {
+        if(this.closable && this.closeButton) {
             this.closeButton.removeEventListener('click', this.handleCloseEvent.bind(this));
         }
 


### PR DESCRIPTION
A modal someties didn't need to be closed, as sometimes we make it appear more visible for some cases, like loading screen, or proccessing something.

I've make a new option name `closable` to set up the close ability, and cancel the autobind when the close button are not available.