### PR TITLE
Add anonymous documentation analytics.

### DIFF
--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -30,4 +30,20 @@
   <script>
     var docsMenu = {{ docPages | jsonify }};
   </script>
+
+  <!-- Matomo -->
+  <script type="text/javascript">
+    var _paq = _paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+      var u="//stats.tomerbe.co.uk/";
+      _paq.push(['setTrackerUrl', u+'piwik.php']);
+      _paq.push(['setSiteId', '1']);
+      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+      g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+    })();
+  </script>
+  <!-- End Matomo Code -->
 </head>


### PR DESCRIPTION
Analytics is collected via a self-hosted version of Matomo. All anonymous options are enabled.