### PR TITLE
Add drag and drop handling to file plugin

### DIFF
--- a/src/plugins/file.js
+++ b/src/plugins/file.js
@@ -26,13 +26,13 @@ class File {
          * The element to use as the trigger.
          * @type {HTMLELement}
          */
-        this.trigger = this.root.querySelector('input');
+        this.input = this.root.querySelector('input');
 
         /**
          * The element to show the file name.
          * @type {HTMLElement}
          */
-        this.target = this.root.querySelector('.file-name');
+        this.filename = this.root.querySelector('.file-name');
 
         this.registerEvents();
     }
@@ -42,7 +42,25 @@ class File {
      * @return {undefined}
      */
     registerEvents() {
-        this.trigger.addEventListener('change', this.handleTriggerChange.bind(this));
+        if (this.filename) {
+            this.input.addEventListener('change', this.handleTriggerChange.bind(this));
+        }
+
+        this.root.addEventListener('dragover', (e) => {
+            e.preventDefault();
+            this.addHoverClass();
+        });
+
+        this.root.addEventListener('dragleave', (e) => {
+            e.preventDefault();
+            this.addHoverClass();
+        });
+
+        this.root.addEventListener('drop', (e) => {
+            e.preventDefault();
+            this.removeHoverClass();
+            this.input.files = e.dataTransfer.files;
+        });
     }
 
     /**
@@ -69,7 +87,7 @@ class File {
      * @return {undefined}
      */
     clearFileName() {
-        this.target.innerHTML = '';
+        this.filename.innerHTML = '';
     }
 
     /**
@@ -78,7 +96,23 @@ class File {
      * @return {undefined}
      */
     setFileName(value) {
-        this.target.innerHTML = value;
+        this.filename.innerHTML = value;
+    }
+
+    /**
+     * Add hover class to root element.
+     * @return {undefined}
+     */
+    addHoverClass() {
+        this.root.classList.add('is-hovered');
+    }
+
+    /**
+     * Remove hover class from root element.
+     * @return {undefined}
+     */
+    removeHoverClass() {
+        this.root.classList.remove('is-hovered');
     }
 
     /**


### PR DESCRIPTION
I changed the names of trigger and target so this plugin is used in multiple ways.

I try to build by `npm run production` but failed with below errors.

```
ERROR in chunk notification [entry]
plugin.min.js
Conflict: Multiple assets emit to the same filename plugin.min.js

ERROR in chunk navbar [entry]
plugin.min.js
Conflict: Multiple assets emit to the same filename plugin.min.js
...
```

This problem is this.
https://stackoverflow.com/questions/42148632/conflict-multiple-assets-emit-to-the-same-filename

I deleted `--output ./dist/plugin.min.js` from the command below and succeeded.

```
package.json
"production": "webpack --config webpack.config.js --mode production --output ./dist/plugin.min.js",
```

but dist files are all minified so I send only core file plugin.

Thanks