### PR TITLE
[Modal]: Remove keyup listener on destroy

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -215,7 +215,7 @@ Bulma._stripScripts = (htmlString) => {
         scripts[i].parentNode.removeChild(scripts[i]);
     }
     
-    return div.innerHTML.replace(/  +/g, ' ');;
+    return div.innerHTML.replace(/  +/g, ' ');
 };
 
 /**
@@ -242,7 +242,7 @@ Bulma.prototype.destroyData = function() {
     Bulma.cache.destroy(this._elem[Bulma.id]);
 
     return this;
-}
+};
 
 document.addEventListener('DOMContentLoaded', () => {
     if(window.hasOwnProperty('bulmaOptions') && window.bulmaOptions.autoParseDocument === false) {

--- a/src/plugins/modal.js
+++ b/src/plugins/modal.js
@@ -139,17 +139,8 @@ class Modal extends Plugin {
         if(this.closable) {
             this.closeButton.addEventListener('click', this.close.bind(this));
 
-            document.addEventListener('keyup', (event) => {
-                if(!this.root.classList.contains('is-active')) {
-                    return;
-                }
-
-                let key = event.key || event.keyCode;
-
-                if(key === 'Escape' || key === 'Esc' || key === 27) {
-                    this.close();
-                }
-            });
+            this.keyupListenerBound = (evt) => this.keyupListener(evt);
+            document.addEventListener('keyup', this.keyupListenerBound);
 
             this.background.addEventListener('click', this.close.bind(this));
         }
@@ -197,6 +188,18 @@ class Modal extends Plugin {
         this.trigger('close');
     }
 
+    keyupListener(event) {
+        if(!this.root.classList.contains('is-active')) {
+            return;
+        }
+
+        let key = event.key || event.keyCode;
+
+        if(key === 'Escape' || key === 'Esc' || key === 27) {
+            this.close();
+        }
+    }
+
     /**
      * Destroy this modal, unregistering element references and removing the modal.
      * @returns {void}
@@ -220,6 +223,8 @@ class Modal extends Plugin {
 
         if(this.closable) {
             this.closeButton = null;
+
+            document.removeEventListener('keyup', this.keyupListenerBound);
         }
 
         this.config.gets = [];


### PR DESCRIPTION
Closes #88

Also fixed two minor code style issues currently present in the master.

_Note_: Unfortunately, I am not sure how to create Modals in the current master with the changed plugin structure. The documented method does not work, an error about "missing root/parent" is thrown by `plugin.js`. Otherwise, I would have added unit tests for the issue as well.